### PR TITLE
fetch関数の修正

### DIFF
--- a/src/lib/functions.js
+++ b/src/lib/functions.js
@@ -11,7 +11,7 @@ export const reAuth = async (currentUser, currentEmail, currentPass) => {
 }
 
 // 例文データの取得。見つからない場合はfalseを返す。
-export const getSentenceById = id => {
+export const fetchSentenceById = id => {
   return new Promise((resolve, reject) => {
     const sentenceRef = firebase.firestore().collection('sentences').doc(id)
 

--- a/src/lib/functions.js
+++ b/src/lib/functions.js
@@ -53,7 +53,7 @@ export const fetchListById = id => {
     const listRef = firebase.firestore().collection('lists').doc(id)
 
     listRef.get().then(doc => {
-      resolve(Object.assign(doc.data(), { id: doc.id }) || false)
+      resolve(doc.exists ? Object.assign(doc.data(), { id: doc.id }) : false)
     }).catch(err => {
       reject(err)
     })

--- a/src/lib/functions.js
+++ b/src/lib/functions.js
@@ -16,7 +16,7 @@ export const fetchSentenceById = id => {
     const sentenceRef = firebase.firestore().collection('sentences').doc(id)
 
     sentenceRef.get().then(doc => {
-      resolve(Object.assign(doc.data(), { id: doc.id }) || false)
+      resolve(doc.exists ? Object.assign(doc.data(), { id: doc.id }) : false)
     }).catch(err => {
       reject(err)
     })

--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -43,7 +43,7 @@ import ErrMsg from '../components/ErrMsg'
 import SentencesList from '../components/SentencesList'
 import LearningCard from '../components/LearningCard'
 import firebase from 'firebase'
-import { fetchListById, getSentenceById } from '../lib/functions'
+import { fetchListById, fetchSentenceById } from '../lib/functions'
 
 export default {
   props: {
@@ -121,7 +121,7 @@ export default {
       try {
         // 選択されている例文のデータを取得
         this.list.sentences.forEach(async sentenceId => {
-          const sentence = await getSentenceById(sentenceId)
+          const sentence = await fetchSentenceById(sentenceId)
           if(sentence) { // 例文データがある場合のみdataに格納する。
             this.listSentences.push(sentence)
           }

--- a/src/views/SelectSentence.vue
+++ b/src/views/SelectSentence.vue
@@ -41,7 +41,7 @@
 import Card from '../components/Card'
 import ErrMsg from '../components/ErrMsg'
 import SentencesList from '../components/SentencesList'
-import { fetchUserSentences, fetchListById, getSentenceById } from '../lib/functions'
+import { fetchUserSentences, fetchListById, fetchSentenceById } from '../lib/functions'
 import _ from 'lodash'
 import firebase from 'firebase'
 
@@ -147,7 +147,7 @@ export default {
       try {
         // 選択されている例文のデータを取得
         this.list.sentences.forEach(async sentenceId => {
-          const sentence = await getSentenceById(sentenceId)
+          const sentence = await fetchSentenceById(sentenceId)
           if(sentence) { // 例文データがある場合のみdataに格納する。
             this.selectedSentences.push(sentence)
           }

--- a/src/views/Sentence.vue
+++ b/src/views/Sentence.vue
@@ -34,7 +34,7 @@
 import Card from '../components/Card'
 import ErrMsg from '../components/ErrMsg'
 import firebase from 'firebase'
-import { getSentenceById } from '../lib/functions'
+import { fetchSentenceById } from '../lib/functions'
 
 export default {
   props: {
@@ -76,7 +76,7 @@ export default {
       async handler() {
         try {
           //例文情報を取得
-          const sentenceData = await getSentenceById(this.id)
+          const sentenceData = await fetchSentenceById(this.id)
 
           if(sentenceData) {
             this.sentence = sentenceData

--- a/src/views/SentenceEdit.vue
+++ b/src/views/SentenceEdit.vue
@@ -36,7 +36,7 @@
 <script>
 import ErrMsg from '../components/ErrMsg'
 import firebase from 'firebase'
-import { getSentenceById } from '../lib/functions'
+import { fetchSentenceById } from '../lib/functions'
 
 export default {
   props: {
@@ -79,7 +79,7 @@ export default {
       async handler() {
         try {
           //例文情報を取得
-          const sentenceData = await getSentenceById(this.id)
+          const sentenceData = await fetchSentenceById(this.id)
 
           if(sentenceData && this.loginUser.id === sentenceData.userId) {
             this.english = sentenceData.english


### PR DESCRIPTION
・getSentenceById関数の名前変更
→「fetchSentenceById」として、他の関数名に合わせる。

・例文データ、リストデータ取得時、削除されているデータを取得しようとするとエラーが出る不具合を修正。
→fetchSentenceById、fetchListById関数内で、データの存在有無をチェックする。
