### PR TITLE
例文詳細画面の修正

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -72,8 +72,7 @@ const router = new Router({
       path: '/sentences/:id',
       name: 'senetncesDetail',
       props: true,
-      component: () => import(/* webpackChunkName: "detail-sentence" */ './views/Sentence.vue'),
-      meta: { requireAuth: true }
+      component: () => import(/* webpackChunkName: "detail-sentence" */ './views/Sentence.vue')
     },
     {
       path: '/sentences/',

--- a/src/views/Sentence.vue
+++ b/src/views/Sentence.vue
@@ -54,7 +54,11 @@ export default {
       return this.$store.state.user.loginUser
     },
     canEdit() {
-      return this.loginUser.id === this.sentence.userId
+      if(this.loginUser && this.sentence) {
+        return this.loginUser.id === this.sentence.userId
+      } else {
+        return false
+      }
     }
   },
   methods: {

--- a/src/views/Sentence.vue
+++ b/src/views/Sentence.vue
@@ -22,7 +22,7 @@
         </dl>
       </Card>
 
-      <div v-if="canEdit" class="btn-group">
+      <div v-if="isOwner" class="btn-group">
         <router-link class="btn btn--yellow" :to="{ name: 'senetncesEdit', params: { id: id } }">編集</router-link>
         <button class="btn btn--pink" @click="deleteItem">削除</button>
       </div>
@@ -53,7 +53,7 @@ export default {
     loginUser() {
       return this.$store.state.user.loginUser
     },
-    canEdit() {
+    isOwner() {
       if(this.loginUser && this.sentence) {
         return this.loginUser.id === this.sentence.userId
       } else {


### PR DESCRIPTION
・未ログイン状態でもページ閲覧できるよう修正
・computedプロパティ「canEdit」の名前を「isOwner」に変更。（他のコンポーネントに命名を合わせるため）