### PR TITLE
マイリストページ、ページタイトルの不具合を修正

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -84,7 +84,7 @@ const router = new Router({
     {
       path: '/lists/mylist',
       name: 'myList',
-      props: true,
+      props: { type: 'mylists' },
       component: Lists,
       meta: { requireAuth: true }
     },

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -16,7 +16,7 @@
           </template>
           <ListsList :lists="lists" class="u-mb-medium" />
           <div class="u-center-text">
-            <router-link :to="{ name: 'myList', params: { type: 'mylists' } }" class="btn btn--yellow btn--big">もっと見る</router-link>
+            <router-link :to="{ name: 'myList' }" class="btn btn--yellow btn--big">もっと見る</router-link>
           </div>
         </Card>
 


### PR DESCRIPTION
「マイリスト」ページをリロードすると、ページタイトルが「リスト一覧」と表示されてしまう不具合を修正。
→コンポーネントから渡していたpropsを、router.jsから渡すように変更。