### PR TITLE
ナビゲーションのCSS修正

### DIFF
--- a/src/components/FooterNav.vue
+++ b/src/components/FooterNav.vue
@@ -62,7 +62,7 @@ export default {
 <style lang="scss" scoped>
 .footer-menu {
   display: none;
-  @include respond(phone) {
+  @include respond(tab-port) {
     display: block;
   }
   width: 100%;

--- a/src/components/FooterNav.vue
+++ b/src/components/FooterNav.vue
@@ -69,7 +69,7 @@ export default {
   position: fixed;
   bottom: 0;
   background-color: rgba($color-blue-dark, .8);
-  padding: 1.6rem 1rem;
+  padding: 1.2rem 1rem;
 
   &__list {
     display: flex;
@@ -90,7 +90,7 @@ export default {
   }
 
   &__icon {
-    margin-bottom: 1rem;
+    margin-bottom: .6rem;
   }
 
   &__text {

--- a/src/components/FooterNav.vue
+++ b/src/components/FooterNav.vue
@@ -68,7 +68,7 @@ export default {
   width: 100%;
   position: fixed;
   bottom: 0;
-  background-color: rgba($color-blue-dark, .8);
+  background-color: $color-blue-dark;
   padding: 1.2rem 1rem;
 
   &__list {


### PR DESCRIPTION
メディアクエリの調整
・ヘッダーナビの消失とフッター追従ナビの出現タイミングを統一。

フッター追従ナビのデザイン変更
・高さを下げる。
・背景色を透過なしに。