### PR TITLE
リスト一覧画面のローディング内容が切り替わらないバグを修正

### DIFF
--- a/src/views/Lists.vue
+++ b/src/views/Lists.vue
@@ -9,7 +9,7 @@
 
       <Card>
         <ListsList :lists="lists" :isShowLikeCount="this.type === 'ranking'" />
-        <infinite-loading @infinite="infiniteLoad"></infinite-loading>
+        <infinite-loading :identifier="identifier" @infinite="infiniteLoad"></infinite-loading>
       </Card>
 
     </div>
@@ -29,7 +29,8 @@ export default {
   data() {
     return {
       lists: [],
-      lastItem: null
+      lastItem: null,
+      identifier: 1
     }
   },
   computed: {
@@ -80,6 +81,14 @@ export default {
       } catch(error) {
         this.$store.dispatch('error/setError', error)
       }
+    }
+  },
+  watch: {
+    // 画面遷移時、ローディング内容をリセットする。
+    type() {
+      this.lists = []
+      this.lastItem = null
+      this.identifier += 1
     }
   }
 }


### PR DESCRIPTION
リスト一覧→ランキング一覧などの画面遷移時に、ローディング内容が切り替わらないバグを修正。
・画面遷移時にローディング内容をリセットする処理を追加