### PR TITLE
ナビゲーションリンクの、スマホ時のhoverを解除

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -35,6 +35,9 @@
 
     &:hover {
       color: $color-pink-light;
+      @include respond(phone) {
+        color: $color-white;
+      }
     }
   }
 }

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -50,6 +50,9 @@ export default {
 
     &:hover {
       color: $color-pink-light;
+      @include respond(phone) {
+        color: $color-white;
+      }
     }
   }
 }

--- a/src/components/MainNav.vue
+++ b/src/components/MainNav.vue
@@ -89,6 +89,9 @@ export default {
 
     &:hover {
       color: $color-pink-light;
+      @include respond(phone) {
+        color: $color-white;
+      }
     }
   }
 }


### PR DESCRIPTION
スマホでの閲覧時、以下のリンクのhoverを解除するよう修正。

・ヘッダーのサイトタイトル
・フッターのサイトタイトル
・ヘッダーナビゲーション